### PR TITLE
perf: optimizing functions

### DIFF
--- a/benchmark.mjs
+++ b/benchmark.mjs
@@ -1,0 +1,49 @@
+/* eslint no-undef: "off" */
+
+import {Buffer} from 'node:buffer';
+import {randomBytes} from 'node:crypto';
+import benchmark from 'benchmark';
+import {
+	base64ToString,
+	concatUint8Arrays,
+	hexToUint8Array,
+	isUint8Array,
+	stringToBase64,
+	stringToUint8Array,
+	uint8ArrayToBase64,
+	uint8ArrayToHex,
+	uint8ArrayToString,
+} from './index.js';
+
+const oneMb = 1024 * 1024;
+const largeUint8Array = new Uint8Array(randomBytes(oneMb).buffer);
+const textFromUint8Array = uint8ArrayToString(largeUint8Array);
+const base64FromUint8Array = Buffer.from(textFromUint8Array).toString('base64');
+const hexFromUint8Array = uint8ArrayToHex(largeUint8Array);
+
+const suite = new benchmark.Suite();
+
+suite.add('isUint8Array', () => isUint8Array(largeUint8Array));
+
+suite.add('concatUint8Arrays with 2 arrays', () => concatUint8Arrays([largeUint8Array, largeUint8Array]));
+
+suite.add('concatUint8Arrays with 3 arrays', () => concatUint8Arrays([largeUint8Array, largeUint8Array]));
+
+suite.add('concatUint8Arrays with 4 arrays', () => concatUint8Arrays([largeUint8Array, largeUint8Array, largeUint8Array, largeUint8Array]));
+
+suite.add('uint8ArrayToString', () => uint8ArrayToString(largeUint8Array));
+
+suite.add('stringToUint8Array', () => stringToUint8Array(textFromUint8Array));
+
+suite.add('uint8ArrayToBase64', () => uint8ArrayToBase64(largeUint8Array));
+
+suite.add('stringToBase64', () => stringToBase64(textFromUint8Array));
+
+suite.add('base64ToString', () => base64ToString(base64FromUint8Array));
+
+suite.add('uint8ArrayToHex', () => uint8ArrayToHex(largeUint8Array));
+
+suite.add('hexToUint8Array', () => hexToUint8Array(hexFromUint8Array));
+
+suite.on('cycle', event => console.log(event.target.toString()));
+suite.run({async: false});

--- a/index.js
+++ b/index.js
@@ -128,11 +128,24 @@ function base64UrlToBase64(base64url) {
 	return base64url.replaceAll('-', '+').replaceAll('_', '/');
 }
 
+// reference: https://phuoc.ng/collection/this-vs-that/concat-vs-push/
+const MAX_BLOCK_SIZE = 65535;
+
 export function uint8ArrayToBase64(array, { urlSafe = false } = {}) {
 	assertUint8Array(array);
 
-	// Required as `btoa` and `atob` don't properly support Unicode: https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem
-	const base64 = globalThis.btoa(String.fromCodePoint(...array));
+	let base64;
+
+	if (array.length < MAX_BLOCK_SIZE) {
+		// Required as `btoa` and `atob` don't properly support Unicode: https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem
+		base64 = globalThis.btoa(String.fromCodePoint(...array));
+	} else {
+		base64 = '';
+		for (let value of array) {
+			base64 += String.fromCodePoint(value);
+		}
+		base64 = globalThis.btoa(base64);
+	}
 
 	return urlSafe ? base64ToBase64Url(base64) : base64;
 }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,16 @@
 const objectToString = Object.prototype.toString;
+const uint8ArrayStringified = '[object Uint8Array]';
 
 export function isUint8Array(value) {
-	return value && objectToString.call(value) === '[object Uint8Array]';
+	if (!value) {
+		return false;
+	}
+
+	if (value.constructor === Uint8Array) {
+		return true;
+	}
+
+	return objectToString.call(value) === uint8ArrayStringified;
 }
 
 export function assertUint8Array(value) {

--- a/index.js
+++ b/index.js
@@ -100,10 +100,11 @@ export function compareUint8Arrays(a, b) {
 
 	return 0;
 }
+const cachedDecoder = new globalThis.TextDecoder();
 
 export function uint8ArrayToString(array) {
 	assertUint8Array(array);
-	return (new globalThis.TextDecoder()).decode(array);
+	return cachedDecoder.decode(array);
 }
 
 function assertString(value) {
@@ -125,7 +126,7 @@ function base64UrlToBase64(base64url) {
 	return base64url.replaceAll('-', '+').replaceAll('_', '/');
 }
 
-export function uint8ArrayToBase64(array, {urlSafe = false} = {}) {
+export function uint8ArrayToBase64(array, { urlSafe = false } = {}) {
 	assertUint8Array(array);
 
 	// Required as `btoa` and `atob` don't properly support Unicode: https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem
@@ -139,9 +140,9 @@ export function base64ToUint8Array(base64String) {
 	return Uint8Array.from(globalThis.atob(base64UrlToBase64(base64String)), x => x.codePointAt(0));
 }
 
-export function stringToBase64(string, {urlSafe = false} = {}) {
+export function stringToBase64(string, { urlSafe = false } = {}) {
 	assertString(string);
-	return uint8ArrayToBase64(stringToUint8Array(string), {urlSafe});
+	return uint8ArrayToBase64(stringToUint8Array(string), { urlSafe });
 }
 
 export function base64ToString(base64String) {
@@ -149,7 +150,7 @@ export function base64ToString(base64String) {
 	return uint8ArrayToString(base64ToUint8Array(base64String));
 }
 
-const byteToHexLookupTable = Array.from({length: 256}, (_, index) => index.toString(16).padStart(2, '0'));
+const byteToHexLookupTable = Array.from({ length: 256 }, (_, index) => index.toString(16).padStart(2, '0'));
 
 export function uint8ArrayToHex(array) {
 	assertUint8Array(array);

--- a/index.js
+++ b/index.js
@@ -113,9 +113,11 @@ function assertString(value) {
 	}
 }
 
+const cachedEncoder = new globalThis.TextEncoder();
+
 export function stringToUint8Array(string) {
 	assertString(string);
-	return (new globalThis.TextEncoder()).encode(string);
+	return cachedEncoder.encode(string);
 }
 
 function base64ToBase64Url(base64) {

--- a/index.js
+++ b/index.js
@@ -137,8 +137,8 @@ export function uint8ArrayToBase64(array, { urlSafe = false } = {}) {
 	let base64;
 
 	if (array.length < MAX_BLOCK_SIZE) {
-		// Required as `btoa` and `atob` don't properly support Unicode: https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem
-		base64 = globalThis.btoa(String.fromCodePoint(...array));
+	// Required as `btoa` and `atob` don't properly support Unicode: https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem
+	base64 = globalThis.btoa(String.fromCodePoint.apply(this, array));
 	} else {
 		base64 = '';
 		for (let value of array) {

--- a/index.js
+++ b/index.js
@@ -100,6 +100,7 @@ export function compareUint8Arrays(a, b) {
 
 	return 0;
 }
+
 const cachedDecoder = new globalThis.TextDecoder();
 
 export function uint8ArrayToString(array) {
@@ -128,22 +129,23 @@ function base64UrlToBase64(base64url) {
 	return base64url.replaceAll('-', '+').replaceAll('_', '/');
 }
 
-// reference: https://phuoc.ng/collection/this-vs-that/concat-vs-push/
-const MAX_BLOCK_SIZE = 65535;
+// Reference: https://phuoc.ng/collection/this-vs-that/concat-vs-push/
+const MAX_BLOCK_SIZE = 65_535;
 
-export function uint8ArrayToBase64(array, { urlSafe = false } = {}) {
+export function uint8ArrayToBase64(array, {urlSafe = false} = {}) {
 	assertUint8Array(array);
 
 	let base64;
 
 	if (array.length < MAX_BLOCK_SIZE) {
 	// Required as `btoa` and `atob` don't properly support Unicode: https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem
-	base64 = globalThis.btoa(String.fromCodePoint.apply(this, array));
+		base64 = globalThis.btoa(String.fromCodePoint.apply(this, array));
 	} else {
 		base64 = '';
-		for (let value of array) {
+		for (const value of array) {
 			base64 += String.fromCodePoint(value);
 		}
+
 		base64 = globalThis.btoa(base64);
 	}
 
@@ -155,9 +157,9 @@ export function base64ToUint8Array(base64String) {
 	return Uint8Array.from(globalThis.atob(base64UrlToBase64(base64String)), x => x.codePointAt(0));
 }
 
-export function stringToBase64(string, { urlSafe = false } = {}) {
+export function stringToBase64(string, {urlSafe = false} = {}) {
 	assertString(string);
-	return uint8ArrayToBase64(stringToUint8Array(string), { urlSafe });
+	return uint8ArrayToBase64(stringToUint8Array(string), {urlSafe});
 }
 
 export function base64ToString(base64String) {
@@ -165,7 +167,7 @@ export function base64ToString(base64String) {
 	return uint8ArrayToString(base64ToUint8Array(base64String));
 }
 
-const byteToHexLookupTable = Array.from({ length: 256 }, (_, index) => index.toString(16).padStart(2, '0'));
+const byteToHexLookupTable = Array.from({length: 256}, (_, index) => index.toString(16).padStart(2, '0'));
 
 export function uint8ArrayToHex(array) {
 	assertUint8Array(array);

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 	"devDependencies": {
 		"ava": "^5.3.1",
 		"typescript": "^5.2.2",
-		"xo": "^0.56.0"
+		"xo": "^0.56.0",
+		"benchmark": "2.1.4"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -126,6 +126,12 @@ test('uint8ArrayToBase64 and base64ToUint8Array', t => {
 	t.deepEqual(base64ToUint8Array(base64), fixture);
 });
 
+test('should handle uint8ArrayToBase64 with 200k items', t => {
+	const fixture = stringToUint8Array('H'.repeat(200_000));
+	const base64 = uint8ArrayToBase64(fixture);
+	t.deepEqual(base64ToUint8Array(base64), fixture);
+});
+
 test('uint8ArrayToBase64 and base64ToUint8Array #2', t => {
 	const fixture = stringToUint8Array('a Ā 𐀀 文 🦄');
 	t.deepEqual(base64ToUint8Array(uint8ArrayToBase64(base64ToUint8Array(uint8ArrayToBase64(fixture)))), fixture);


### PR DESCRIPTION
Before:

```
isUint8Array x 30,520,055 ops/sec ±1.32% (93 runs sampled)
uint8ArrayToString x 102 ops/sec ±0.41% (76 runs sampled)
stringToUint8Array x 165 ops/sec ±0.16% (85 runs sampled)
uint8ArrayToBase64: 
stringToBase64: 
```

> The values are empty because it only throws errors.

Now:

```
isUint8Array x 160,822,491 ops/sec ±1.10% (100 runs sampled)
uint8ArrayToString x 103 ops/sec ±0.19% (76 runs sampled)
stringToUint8Array x 164 ops/sec ±0.21% (84 runs sampled)
uint8ArrayToBase64 x 16.44 ops/sec ±6.55% (37 runs sampled)
stringToBase64 x 8.37 ops/sec ±5.35% (25 runs sampled)
```


Full Execution:

```
isUint8Array x 160,822,491 ops/sec ±1.10% (100 runs sampled)
concatUint8Arrays with 2 arrays x 3,125 ops/sec ±7.13% (71 runs sampled)
concatUint8Arrays with 3 arrays x 3,699 ops/sec ±3.41% (82 runs sampled)
concatUint8Arrays with 4 arrays x 1,974 ops/sec ±2.87% (84 runs sampled)
uint8ArrayToString x 103 ops/sec ±0.19% (76 runs sampled)
stringToUint8Array x 164 ops/sec ±0.21% (84 runs sampled)
uint8ArrayToBase64 x 16.44 ops/sec ±6.55% (37 runs sampled)
stringToBase64 x 8.37 ops/sec ±5.35% (25 runs sampled)
base64ToString x 4.30 ops/sec ±0.60% (15 runs sampled)
uint8ArrayToHex x 20.14 ops/sec ±5.41% (38 runs sampled)
hexToUint8Array x 38.27 ops/sec ±0.52% (67 runs sampled)
```

> I added benchmark for all the functions but I didn't necessarily optimize all of them.

The changes were mostly to address the issue with larger arrays and some of the optimizations will only be noticeable on tiny arrays (`uint8ArrayToString` and `stringToUint8Array`).