### PR TITLE
Perf: use subtraction instead of multiple compares in compareUint8Arrays

### DIFF
--- a/benchmark.mjs
+++ b/benchmark.mjs
@@ -18,6 +18,7 @@ import {
 
 const oneMb = 1024 * 1024;
 const largeUint8Array = new Uint8Array(randomBytes(oneMb).buffer);
+// eslint-disable-next-line unicorn/prefer-spread
 const largeUint8ArrayDup = largeUint8Array.slice();
 const textFromUint8Array = uint8ArrayToString(largeUint8Array);
 const base64FromUint8Array = Buffer.from(textFromUint8Array).toString('base64');

--- a/benchmark.mjs
+++ b/benchmark.mjs
@@ -5,6 +5,7 @@ import {randomBytes} from 'node:crypto';
 import benchmark from 'benchmark';
 import {
 	base64ToString,
+	compareUint8Arrays,
 	concatUint8Arrays,
 	hexToUint8Array,
 	isUint8Array,
@@ -17,6 +18,7 @@ import {
 
 const oneMb = 1024 * 1024;
 const largeUint8Array = new Uint8Array(randomBytes(oneMb).buffer);
+const largeUint8ArrayDup = largeUint8Array.slice();
 const textFromUint8Array = uint8ArrayToString(largeUint8Array);
 const base64FromUint8Array = Buffer.from(textFromUint8Array).toString('base64');
 const hexFromUint8Array = uint8ArrayToHex(largeUint8Array);
@@ -24,6 +26,8 @@ const hexFromUint8Array = uint8ArrayToHex(largeUint8Array);
 const suite = new benchmark.Suite();
 
 suite.add('isUint8Array', () => isUint8Array(largeUint8Array));
+
+suite.add('compareUint8Arrays', () => compareUint8Arrays(largeUint8Array, largeUint8ArrayDup));
 
 suite.add('concatUint8Arrays with 2 arrays', () => concatUint8Arrays([largeUint8Array, largeUint8Array]));
 

--- a/benchmark.mjs
+++ b/benchmark.mjs
@@ -19,7 +19,7 @@ import {
 const oneMb = 1024 * 1024;
 const largeUint8Array = new Uint8Array(randomBytes(oneMb).buffer);
 // eslint-disable-next-line unicorn/prefer-spread
-const largeUint8ArrayDup = largeUint8Array.slice();
+const largeUint8ArrayDuplicate = largeUint8Array.slice();
 const textFromUint8Array = uint8ArrayToString(largeUint8Array);
 const base64FromUint8Array = Buffer.from(textFromUint8Array).toString('base64');
 const hexFromUint8Array = uint8ArrayToHex(largeUint8Array);
@@ -28,7 +28,7 @@ const suite = new benchmark.Suite();
 
 suite.add('isUint8Array', () => isUint8Array(largeUint8Array));
 
-suite.add('compareUint8Arrays', () => compareUint8Arrays(largeUint8Array, largeUint8ArrayDup));
+suite.add('compareUint8Arrays', () => compareUint8Arrays(largeUint8Array, largeUint8ArrayDuplicate));
 
 suite.add('concatUint8Arrays with 2 arrays', () => concatUint8Arrays([largeUint8Array, largeUint8Array]));
 

--- a/index.js
+++ b/index.js
@@ -79,26 +79,15 @@ export function compareUint8Arrays(a, b) {
 	const length = Math.min(a.length, b.length);
 
 	for (let index = 0; index < length; index++) {
-		if (a[index] < b[index]) {
-			return -1;
-		}
-
-		if (a[index] > b[index]) {
-			return 1;
+		const diff = a[index] - b[index];
+		if (diff) {
+			return Math.sign(diff);
 		}
 	}
 
 	// At this point, all the compared elements are equal.
 	// The shorter array should come first if the arrays are of different lengths.
-	if (a.length > b.length) {
-		return 1;
-	}
-
-	if (a.length < b.length) {
-		return -1;
-	}
-
-	return 0;
+	return Math.sign(a.length - b.length);
 }
 
 const cachedDecoder = new globalThis.TextDecoder();

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ export function compareUint8Arrays(a, b) {
 
 	for (let index = 0; index < length; index++) {
 		const diff = a[index] - b[index];
-		if (diff) {
+		if (diff !== 0) {
 			return Math.sign(diff);
 		}
 	}


### PR DESCRIPTION
This looks to have an almost 20% performance win on my machine, mostly by removing one comparison in the tight loop.

- Used [Math.sign](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sign) to clamp the outputs so that the tests still pass.
- Added missing benchmark for compareUint8Arrays

Comparison of benchmark outputs on my machine:
Before: `compareUint8Arrays x 479 ops/sec ±0.10% (95 runs sampled)`
After: `compareUint8Arrays x 574 ops/sec ±3.75% (96 runs sampled)`