### PR TITLE
Add includes method and some missing benchmarks

### DIFF
--- a/benchmark.mjs
+++ b/benchmark.mjs
@@ -14,15 +14,20 @@ import {
 	uint8ArrayToBase64,
 	uint8ArrayToHex,
 	uint8ArrayToString,
+	getUintBE,
+	indexOf,
+	includes,
 } from './index.js';
 
 const oneMb = 1024 * 1024;
 const largeUint8Array = new Uint8Array(randomBytes(oneMb).buffer);
 // eslint-disable-next-line unicorn/prefer-spread
 const largeUint8ArrayDuplicate = largeUint8Array.slice();
+const partOfUint8Array = largeUint8Array.slice(-1024);
 const textFromUint8Array = uint8ArrayToString(largeUint8Array);
 const base64FromUint8Array = Buffer.from(textFromUint8Array).toString('base64');
 const hexFromUint8Array = uint8ArrayToHex(largeUint8Array);
+const view = new DataView(largeUint8Array.buffer, 0, 10);
 
 const suite = new benchmark.Suite();
 
@@ -38,6 +43,8 @@ suite.add('concatUint8Arrays with 4 arrays', () => concatUint8Arrays([largeUint8
 
 suite.add('uint8ArrayToString', () => uint8ArrayToString(largeUint8Array));
 
+suite.add('uint8ArrayToString - latin1', () => uint8ArrayToString(largeUint8Array, 'latin1'));
+
 suite.add('stringToUint8Array', () => stringToUint8Array(textFromUint8Array));
 
 suite.add('uint8ArrayToBase64', () => uint8ArrayToBase64(largeUint8Array));
@@ -49,6 +56,12 @@ suite.add('base64ToString', () => base64ToString(base64FromUint8Array));
 suite.add('uint8ArrayToHex', () => uint8ArrayToHex(largeUint8Array));
 
 suite.add('hexToUint8Array', () => hexToUint8Array(hexFromUint8Array));
+
+suite.add('getUintBE', () => getUintBE(view));
+
+suite.add('indexOf', () => indexOf(largeUint8Array, partOfUint8Array));
+
+suite.add('includes', () => includes(largeUint8Array, partOfUint8Array));
 
 suite.on('cycle', event => console.log(event.target.toString()));
 suite.run({async: false});

--- a/index.d.ts
+++ b/index.d.ts
@@ -300,7 +300,7 @@ Returns true if the value is included, otherwise false.
 
 Replacement for [`Buffer#includes`](https://nodejs.org/api/buffer.html#bufincludesvalue-byteoffset-encoding). `Uint8Array#includes` only takes a number which is different from Buffer's `includes` implementation.
 
-```js
+```
 import {includes} from 'uint8array-extras';
 
 const byteArray = new Uint8Array([0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef]);

--- a/index.d.ts
+++ b/index.d.ts
@@ -292,3 +292,21 @@ console.log(indexOf(byteArray, new Uint8Array([0x78, 0x90])));
 ```
 */
 export function indexOf(array: Uint8Array, value: Uint8Array): number;
+
+/**
+Checks if the given sequence of bytes (`value`) is within the given `Uint8Array` (`array`).
+
+Returns true if the value is included, otherwise false.
+
+Replacement for [`Buffer#includes`](https://nodejs.org/api/buffer.html#bufincludesvalue-byteoffset-encoding). `Uint8Array#includes` only takes a number which is different from Buffer's `includes` implementation.
+
+```js
+import {includes} from 'uint8array-extras';
+
+const byteArray = new Uint8Array([0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef]);
+
+console.log(includes(byteArray, new Uint8Array([0x78, 0x90])));
+//=> true
+```
+*/
+export function includes(array: Uint8Array, value: Uint8Array): boolean;

--- a/index.js
+++ b/index.js
@@ -291,3 +291,10 @@ export function indexOf(array, value) {
 
 	return -1;
 }
+
+/**
+@param {Uint8Array} array
+@param {Uint8Array} value
+@returns {boolean}
+*/
+export const includes = (array, value) => indexOf(array, value) !== -1;

--- a/index.js
+++ b/index.js
@@ -297,4 +297,6 @@ export function indexOf(array, value) {
 @param {Uint8Array} value
 @returns {boolean}
 */
-export const includes = (array, value) => indexOf(array, value) !== -1;
+export function includes(array, value) {
+	return indexOf(array, value) !== -1;
+}

--- a/readme.md
+++ b/readme.md
@@ -282,3 +282,20 @@ const byteArray = new Uint8Array([0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef
 console.log(indexOf(byteArray, new Uint8Array([0x78, 0x90])));
 //=> 3
 ```
+
+### `includes(array: Uint8Array, value: Uint8Array): boolean`
+
+Checks if the given sequence of bytes (`value`) within the given `Uint8Array` (`array`).
+
+Returns true if the value is included, otherwise false.
+
+Replacement for [`Buffer#includes`](https://nodejs.org/api/buffer.html#bufincludesvalue-byteoffset-encoding). `Uint8Array#includes` only takes a number which is different from Buffer's `includes` implementation.
+
+```js
+import {includes} from 'uint8array-extras';
+
+const byteArray = new Uint8Array([0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef]);
+
+console.log(includes(byteArray, new Uint8Array([0x78, 0x90])));
+//=> true
+```

--- a/readme.md
+++ b/readme.md
@@ -285,7 +285,7 @@ console.log(indexOf(byteArray, new Uint8Array([0x78, 0x90])));
 
 ### `includes(array: Uint8Array, value: Uint8Array): boolean`
 
-Checks if the given sequence of bytes (`value`) within the given `Uint8Array` (`array`).
+Checks if the given sequence of bytes (`value`) is within the given `Uint8Array` (`array`).
 
 Returns true if the value is included, otherwise false.
 

--- a/test.js
+++ b/test.js
@@ -232,6 +232,6 @@ test('indexOf - single element found', t => {
 
 test('includes', t => {
 	const fixture = [0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef]; // eslint-disable-line unicorn/number-literal-case
-	t.is(includes(new Uint8Array(fixture), new Uint8Array([0x78, 0x90])), true);
-	t.is(includes(new Uint8Array(fixture), new Uint8Array([0x90, 0x78])), false);
+	t.true(includes(new Uint8Array(fixture), new Uint8Array([0x78, 0x90])));
+	t.false(includes(new Uint8Array(fixture), new Uint8Array([0x90, 0x78])));
 });

--- a/test.js
+++ b/test.js
@@ -16,6 +16,7 @@ import {
 	hexToUint8Array,
 	getUintBE,
 	indexOf,
+	includes,
 } from './index.js';
 
 test('isUint8Array', t => {
@@ -227,4 +228,10 @@ test('indexOf - single element found', t => {
 	const fixture = [0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef]; // eslint-disable-line unicorn/number-literal-case
 	const singleElement = [0x56];
 	t.is(indexOf(new Uint8Array(fixture), new Uint8Array(singleElement)), 2);
+});
+
+test('includes', t => {
+	const fixture = [0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef]; // eslint-disable-line unicorn/number-literal-case
+	t.is(includes(new Uint8Array(fixture), new Uint8Array([0x78, 0x90])), true);
+	t.is(includes(new Uint8Array(fixture), new Uint8Array([0x90, 0x78])), false);
 });


### PR DESCRIPTION
As suggested [here](https://github.com/sindresorhus/file-type/pull/633#discussion_r1666651196):

> From this usage, it looks like it would be useful to have a includes method in uint8array-extras too.

Also added `getUintBE`, `indexOf`, and `includes` to `benchmark.mjs`

