### PR TITLE
Avoid using Uint8Array generic types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -92,7 +92,7 @@ console.log(concatUint8Arrays([a, b]));
 //=> Uint8Array [1, 2, 3, 4, 5, 6]
 ```
 */
-export function concatUint8Arrays(arrays: Uint8Array[], totalLength?: number): Uint8Array<ArrayBuffer>;
+export function concatUint8Arrays(arrays: Uint8Array[], totalLength?: number): Uint8Array;
 
 /**
 Check if two arrays are identical by verifying that they contain the same bytes in the same sequence.
@@ -174,7 +174,7 @@ console.log(stringToUint8Array('Hello'));
 //=> Uint8Array [72, 101, 108, 108, 111]
 ```
 */
-export function stringToUint8Array(string: string): Uint8Array<ArrayBuffer>;
+export function stringToUint8Array(string: string): Uint8Array;
 
 /**
 Convert a `Uint8Array` to a Base64-encoded string.
@@ -210,7 +210,7 @@ console.log(base64ToUint8Array('SGVsbG8='));
 //=> Uint8Array [72, 101, 108, 108, 111]
 ```
 */
-export function base64ToUint8Array(string: string): Uint8Array<ArrayBuffer>;
+export function base64ToUint8Array(string: string): Uint8Array;
 
 /**
 Encode a string to a Base64-encoded string.
@@ -276,7 +276,7 @@ console.log(hexToUint8Array('48656c6c6f'));
 //=> Uint8Array [72, 101, 108, 108, 111]
 ```
 */
-export function hexToUint8Array(hexString: string): Uint8Array<ArrayBuffer>;
+export function hexToUint8Array(hexString: string): Uint8Array;
 
 /**
 Read `DataView#byteLength` number of bytes from the given view, up to 48-bit.


### PR DESCRIPTION
Changes `Uint8Array` return types in **non generic** types.

**Motivation**
Typed array generics were added in TS 5.7 for internal type modeling of ES2024’s resizable `ArrayBuffer` and growable `SharedArrayBuffer`, not as part of a stable public API surface. This is supported by several observations:

- The TypeScript standard library **never exposes these generics** in public APIs. All user-facing functions still return plain `Uint8Array`.
- The value constructor `Uint8Array` remains **non generic**, so in real .ts code the merged symbol is non generic, and consumers cannot write `Uint8Array<ArrayBuffer>` without hitting `TS2315`.
- Typed-array generics were introduced in TS 5.7 to preserve `.buffer` inference for ES2024’s resizable `ArrayBuffer` and growable `SharedArrayBuffer`.

In other words, exporting `Uint8Array<ArrayBuffer>` breaks compatibility with pre-5.7 TypeScript, and also breaks any consumer compiling against older lib targets, without providing a meaningful benefit.

Resolves #18 

Reverts : cb87fcdbecf6824b8f5daa247abad8decd866b50