### PR TITLE
Update CI GitHub action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,13 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 24
+          - 22
           - 20
           - 18
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install


### PR DESCRIPTION
- Include Node v22 & v24 tests
- Update Github action dependencies

(Initially created this PR because I thought the Typing were not checked, I missed that already included as part the `test` script, defined in `package.json`.) 