### PR TITLE
Update xo to version 1.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"node": ">=18"
 	},
 	"scripts": {
-		"test": "xo && ava && tsc index.d.ts"
+		"test": "xo && ava && tsc -p ."
 	},
 	"files": [
 		"index.js",
@@ -48,7 +48,7 @@
 	"devDependencies": {
 		"ava": "^6.0.1",
 		"typescript": "^5.3.3",
-		"xo": "^0.56.0",
+		"xo": "^1.2.3",
 		"benchmark": "2.1.4"
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"include": ["index.d.ts"],
+	"compilerOptions": {
+		"lib": ["es2020"]
+	}
+}

--- a/xo.config.js
+++ b/xo.config.js
@@ -1,0 +1,9 @@
+const xoConfig = [
+	{
+		ignores: [
+			'index.d.ts',
+		],
+	},
+];
+
+export default xoConfig;


### PR DESCRIPTION
Update [xo](https://www.npmjs.com/package/xo) to version 1.2.3

Added `tsconfig.json`, to specify ES2020 dependent typings.
Avoid `index.d.ts` being parsed by xo.

Please review these changed, I am not very familiar with [xo](https://www.npmjs.com/package/xo).